### PR TITLE
feat: hide mask

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,6 +105,10 @@ canvas {
   align-items: center;
 }
 
+canvas:hover {
+  background: transparent;
+}
+
 button {
   background-color: var(--var-button-bg-color);
   color: var(--var-button-fg-color);


### PR DESCRIPTION
I wanted to add a way to see the result, but without the mask-pattern. i.e. what would this look like on white, what would this look like on black (are the obvious two choices).

This PR is just "hover over it to hide the mask", and therefore see the result on white/black depending if your colour scheme is set to light/dark. Which isn't quite the same thing.
